### PR TITLE
Prefer no braces for inline fat arrow functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1577,7 +1577,7 @@ person.save().then(function() {
 }.bind(this));
 
 // good
-var names = people.map((person) => { return person.name; });
+var names = people.map((person) => person.name);
 
 // good
 person.save().then(()=> {


### PR DESCRIPTION
I feel that this reads more cleanly.
